### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3.5.2
  
     - name: setup dotnet
-      uses: actions/setup-dotnet@v3.0.3
+      uses: actions/setup-dotnet@v3.1.0
       with:
         dotnet-version: 7.0.x
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v3.1.0](https://github.com/actions/setup-dotnet/releases/tag/v3.1.0)** on 2023-05-25T12:07:16Z
