### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v3.5.3
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
         
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@v3.5.3
  
     - name: setup dotnet
-      uses: actions/setup-dotnet@v3.0.3
+      uses: actions/setup-dotnet@v3.2.0
       with:
         dotnet-version: 7.0.x
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v3.2.0](https://github.com/actions/setup-dotnet/releases/tag/v3.2.0)** on 2023-05-29T11:43:01Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.3](https://github.com/actions/checkout/releases/tag/v3.5.3)** on 2023-06-09T15:05:56Z
