### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.2.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
         
     steps:
-    - uses: actions/checkout@v4.1.6
+    - uses: actions/checkout@v4.2.0
  
     - name: setup dotnet
-      uses: actions/setup-dotnet@v4.0.0
+      uses: actions/setup-dotnet@v4.0.1
       with:
         dotnet-version: 8.0.x
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v4.0.1](https://github.com/actions/setup-dotnet/releases/tag/v4.0.1)** on 2024-07-09T14:31:19Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.0](https://github.com/actions/checkout/releases/tag/v4.2.0)** on 2024-09-25T17:52:55Z
