### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4.2.2
  
     - name: setup dotnet
-      uses: actions/setup-dotnet@v4.2.0
+      uses: actions/setup-dotnet@v4.3.1
       with:
         dotnet-version: 8.0.x
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v4.3.1](https://github.com/actions/setup-dotnet/releases/tag/v4.3.1)** on 2025-03-17T02:59:06Z
