### PR TITLE
Make AWS S3 AccessKey and SecretKey Optional to Support IAM Roles

### DIFF
--- a/assets/Squidex.Assets.S3/AmazonS3AssetOptions.cs
+++ b/assets/Squidex.Assets.S3/AmazonS3AssetOptions.cs
@@ -33,15 +33,5 @@ public sealed class AmazonS3AssetOptions : IValidatableOptions
         {
             yield return new ConfigurationError("Value is required.", nameof(Bucket));
         }
-
-        if (string.IsNullOrWhiteSpace(AccessKey))
-        {
-            yield return new ConfigurationError("Value is required.", nameof(AccessKey));
-        }
-
-        if (string.IsNullOrWhiteSpace(SecretKey))
-        {
-            yield return new ConfigurationError("Value is required.", nameof(SecretKey));
-        }
     }
 }

--- a/assets/Squidex.Assets.S3/AmazonS3AssetStore.cs
+++ b/assets/Squidex.Assets.S3/AmazonS3AssetStore.cs
@@ -49,7 +49,15 @@ public sealed class AmazonS3AssetStore(IOptions<AmazonS3AssetOptions> options) :
                 amazonS3Config.RegionEndpoint = RegionEndpoint.GetBySystemName(options.RegionName);
             }
 
-            s3Client = new AmazonS3Client(options.AccessKey, options.SecretKey, amazonS3Config);
+            if (!string.IsNullOrWhiteSpace(options.AccessKey) && !string.IsNullOrWhiteSpace(options.SecretKey))
+            {
+                s3Client = new AmazonS3Client(options.AccessKey, options.SecretKey, amazonS3Config);
+            }
+            else
+            {
+                s3Client = new AmazonS3Client(amazonS3Config);
+            }
+
             s3Transfer = new TransferUtility(s3Client);
 
             var exists = await AmazonS3Util.DoesS3BucketExistV2Async(s3Client, options.Bucket);


### PR DESCRIPTION
## Problem
Currently, the S3 asset store implementation requires explicit AWS access key and secret key credentials. This limitation prevents using other AWS authentication methods, particularly IAM roles through service accounts in Kubernetes environments.

## Solution
Modified the S3 asset store to make AccessKey and SecretKey optional. When these credentials are not provided, the AWS SDK will fall back to other authentication methods, including:
- IAM roles for service accounts in Kubernetes
- Instance profiles
- Other AWS credential providers in the authentication chain

## Changes
- Removed the mandatory validation for AccessKey and SecretKey in `AmazonS3AssetOptions`
- Updated `AmazonS3AssetStore` to conditionally initialize the S3 client:
  - If AccessKey and SecretKey are provided, use credential-based authentication
  - If credentials are not provided, let AWS SDK handle authentication through IAM roles or other methods

## Testing
- [ ]

## Impact
This change enhances deployment flexibility by supporting:
- Traditional access key authentication
- IAM roles for service accounts in Kubernetes
- EC2 instance profiles
- Other AWS credential provider chain methods

No breaking changes for existing implementations using access keys.