### PR TITLE
fix: restore IRSA support for S3 asset store

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/squidex/squidex</PackageProjectUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>8.0.0</Version>
+    <Version>8.0.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/assets/Squidex.Assets.S3/AmazonS3AssetStore.cs
+++ b/assets/Squidex.Assets.S3/AmazonS3AssetStore.cs
@@ -254,11 +254,12 @@ public sealed class AmazonS3AssetStore(IOptions<AmazonS3AssetOptions> options) :
                 DisableDefaultChecksumValidation = false,
             };
 
-            if (stream.GetLengthOrZero() <= 0)
+            if (!stream.CanSeek)
             {
                 await using (var tempStream = TempHelper.GetTempStream())
                 {
                     await stream.CopyToAsync(tempStream, ct);
+                    tempStream.Position = 0;
 
                     request.InputStream = tempStream;
 
@@ -267,7 +268,7 @@ public sealed class AmazonS3AssetStore(IOptions<AmazonS3AssetOptions> options) :
             }
             else
             {
-                request.InputStream = new SeekFakerStream(stream);
+                request.InputStream = stream;
                 request.AutoCloseStream = false;
 
                 await s3Transfer.UploadAsync(request, ct);

--- a/assets/Squidex.Assets.S3/Squidex.Assets.S3.csproj
+++ b/assets/Squidex.Assets.S3/Squidex.Assets.S3.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="4.0.19.1" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.20" />
     <PackageReference Include="Meziantou.Analyzer" Version="3.0.26">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- add an explicit AWSSDK.SecurityToken dependency so IRSA/web-identity credentials work again in the S3 asset store
- use a real seekable temp stream for non-seekable S3 uploads instead of SeekFakerStream
- avoid masking the original S3 startup failure behind retry rewind errors

## Validation
- reproduced the startup failure with 7.22.0+ in EKS using S3 + IRSA
- validated the patched image in isolated QA and sandbox pods
- validated the patched image in the sandbox live deployment

## Related
- Squidex/squidex issue: https://github.com/Squidex/squidex/issues/1309