### PR TITLE
DeepL: added Glossary and HTML functionality

### DIFF
--- a/text/Squidex.Text/Translations/DeepL/DeepLTranslationOptions.cs
+++ b/text/Squidex.Text/Translations/DeepL/DeepLTranslationOptions.cs
@@ -11,6 +11,12 @@ public sealed class DeepLTranslationOptions
 {
     public string AuthKey { get; set; }
 
+    public string? GlossaryById { get; set; }
+
+    public string? GlossaryByName { get; set; }
+
+    public string? TagHandling { get; set; }
+
     public decimal CostsPerCharacterInEUR { get; set; } = 20m / 1_000_000;
 
     public Dictionary<string, string> Mapping { get; set; }

--- a/text/Squidex.Text/Translations/DeepL/DeepLTranslationService.cs
+++ b/text/Squidex.Text/Translations/DeepL/DeepLTranslationService.cs
@@ -198,7 +198,13 @@ public sealed class DeepLTranslationService(IHttpClientFactory httpClientFactory
         }
         catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.BadRequest)
         {
+            InvalidateGlossaryCacheIfResolved(glossaryId);
             AddError(TranslationResult.LanguageNotSupported);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.NotFound)
+        {
+            InvalidateGlossaryCacheIfResolved(glossaryId);
+            AddError(TranslationResult.Failed(ex));
         }
         catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
         {
@@ -227,6 +233,15 @@ public sealed class DeepLTranslationService(IHttpClientFactory httpClientFactory
         httpClient.DefaultRequestHeaders.Add("Authorization", $"DeepL-Auth-Key {options.AuthKey}");
 
         return httpClient;
+    }
+
+    private void InvalidateGlossaryCacheIfResolved(string? glossaryId)
+    {
+        if (!string.IsNullOrWhiteSpace(glossaryId) && glossaryId == resolvedGlossaryId)
+        {
+            resolvedGlossaryId = null;
+            glossaryResolved = false;
+        }
     }
 
     private static string GetSourceLanguage(string language, string? fallback)

--- a/text/Squidex.Text/Translations/DeepL/DeepLTranslationService.cs
+++ b/text/Squidex.Text/Translations/DeepL/DeepLTranslationService.cs
@@ -19,6 +19,8 @@ public sealed class DeepLTranslationService(IHttpClientFactory httpClientFactory
     private const string UrlPaid = "https://api.deepl.com/v2/translate";
     private const string UrlFree = "https://api-free.deepl.com/v2/translate";
     private readonly DeepLTranslationOptions options = options.Value;
+    private string? resolvedGlossaryId;
+    private bool glossaryResolved;
 
     private sealed class TranslationsDto
     {
@@ -33,6 +35,36 @@ public sealed class DeepLTranslationService(IHttpClientFactory httpClientFactory
 
         [JsonPropertyName("detected_source_language")]
         public string DetectedSourceLanguage { get; set; }
+    }
+
+    private sealed class GlossariesDto
+    {
+        [JsonPropertyName("glossaries")]
+        public GlossaryDto[] Glossaries { get; set; }
+    }
+
+    private sealed class GlossaryDto
+    {
+        [JsonPropertyName("glossary_id")]
+        public string GlossaryId { get; set; } // "def3a26b-3e84-45b3-84ae-0c0aaf3525f7"
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } // "My Glossary"
+
+        [JsonPropertyName("ready")]
+        public bool Ready { get; set; } // true
+
+        [JsonPropertyName("source_lang")]
+        public string SourceLang { get; set; } // "EN"
+
+        [JsonPropertyName("target_lang")]
+        public string TargetLang { get; set; } // "DE"
+
+        [JsonPropertyName("creation_time")]
+        public DateTime CreationTime { get; set; } // "2021-08-03T14:16:18.329Z"
+
+        [JsonPropertyName("entry_count")]
+        public int EntryCount { get; set; } // 1
     }
 
     public bool IsConfigured { get; } = !string.IsNullOrWhiteSpace(options.Value.AuthKey);
@@ -80,6 +112,64 @@ public sealed class DeepLTranslationService(IHttpClientFactory httpClientFactory
             UrlPaid;
 
         using var httpClient = CreateClient();
+
+        var glossaryId = options.GlossaryById;
+
+        if (string.IsNullOrWhiteSpace(glossaryId) && glossaryResolved)
+        {
+            glossaryId = resolvedGlossaryId;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.GlossaryByName) && string.IsNullOrWhiteSpace(glossaryId) && !glossaryResolved)
+        {
+            glossaryResolved = true;
+
+            var glossaryUrl = url.Replace("/translate", "/glossaries");
+            using var glossaryHttpRequest = new HttpRequestMessage(HttpMethod.Get, glossaryUrl);
+            using var glossaryHttpResponse = await httpClient.SendAsync(glossaryHttpRequest, ct);
+
+            try
+            {
+                glossaryHttpResponse.EnsureSuccessStatusCode();
+
+                var glossaryJsonString = await glossaryHttpResponse.Content.ReadAsStringAsync(ct);
+                var glossaryJsonResponse = JsonSerializer.Deserialize<GlossariesDto>(glossaryJsonString)!;
+
+                foreach (var glossary in glossaryJsonResponse.Glossaries)
+                {
+                    if (options.GlossaryByName.Equals(glossary.Name, StringComparison.Ordinal))
+                    {
+                        if (glossary.Ready)
+                        {
+                            glossaryId = glossary.GlossaryId;
+                            resolvedGlossaryId = glossaryId;
+                        }
+                        else
+                        {
+                            glossaryResolved = false;
+                        }
+
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                glossaryResolved = false;
+                AddError(TranslationResult.Failed(ex));
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(glossaryId))
+        {
+            parameters.Add(new KeyValuePair<string, string>("glossary_id", glossaryId));
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.TagHandling))
+        {
+            parameters.Add(new KeyValuePair<string, string>("tag_handling", options.TagHandling));
+        }
+
         using var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
         {
              Content = new FormUrlEncodedContent(parameters!),

--- a/text/Squidex.Text/Translations/DeepL/DeepLTranslationService.cs
+++ b/text/Squidex.Text/Translations/DeepL/DeepLTranslationService.cs
@@ -5,6 +5,7 @@
 //  All rights reserved. Licensed under the MIT license.
 // ==========================================================================
 
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Text.Json;
@@ -19,7 +20,7 @@ public sealed class DeepLTranslationService(IHttpClientFactory httpClientFactory
     private const string UrlPaid = "https://api.deepl.com/v2/translate";
     private const string UrlFree = "https://api-free.deepl.com/v2/translate";
     private readonly DeepLTranslationOptions options = options.Value;
-    private string? resolvedGlossaryId;
+    private readonly ConcurrentDictionary<string, string?> glossaryCache = new ();
     private bool glossaryResolved;
 
     private sealed class TranslationsDto
@@ -55,10 +56,10 @@ public sealed class DeepLTranslationService(IHttpClientFactory httpClientFactory
         public bool Ready { get; set; } // true
 
         [JsonPropertyName("source_lang")]
-        public string SourceLang { get; set; } // "EN"
+        public string SourceLang { get; set; } // "en"
 
         [JsonPropertyName("target_lang")]
-        public string TargetLang { get; set; } // "DE"
+        public string TargetLang { get; set; } // "de"
 
         [JsonPropertyName("creation_time")]
         public DateTime CreationTime { get; set; } // "2021-08-03T14:16:18.329Z"
@@ -91,9 +92,12 @@ public sealed class DeepLTranslationService(IHttpClientFactory httpClientFactory
             return results;
         }
 
+        var sourceCode = sourceLanguage != null ? GetLanguageCode(sourceLanguage) : null;
+        var targetCode = GetLanguageCode(targetLanguage);
+
         var parameters = new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>("target_lang", GetLanguageCode(targetLanguage)),
+            new KeyValuePair<string, string>("target_lang", targetCode),
         };
 
         foreach (var text in textsArray)
@@ -101,9 +105,9 @@ public sealed class DeepLTranslationService(IHttpClientFactory httpClientFactory
             parameters.Add(new KeyValuePair<string, string>("text", text));
         }
 
-        if (sourceLanguage != null)
+        if (sourceCode != null)
         {
-            parameters.Add(new KeyValuePair<string, string>("source_lang", GetLanguageCode(sourceLanguage)));
+            parameters.Add(new KeyValuePair<string, string>("source_lang", sourceCode));
         }
 
         var url =
@@ -115,48 +119,46 @@ public sealed class DeepLTranslationService(IHttpClientFactory httpClientFactory
 
         var glossaryId = options.GlossaryById;
 
-        if (string.IsNullOrWhiteSpace(glossaryId) && glossaryResolved)
+        if (string.IsNullOrWhiteSpace(glossaryId) && sourceCode != null)
         {
-            glossaryId = resolvedGlossaryId;
-        }
+            var langPairKey = $"{sourceCode}_{targetCode}";
 
-        if (!string.IsNullOrWhiteSpace(options.GlossaryByName) && string.IsNullOrWhiteSpace(glossaryId) && !glossaryResolved)
-        {
-            glossaryResolved = true;
-
-            var glossaryUrl = url.Replace("/translate", "/glossaries");
-            using var glossaryHttpRequest = new HttpRequestMessage(HttpMethod.Get, glossaryUrl);
-            using var glossaryHttpResponse = await httpClient.SendAsync(glossaryHttpRequest, ct);
-
-            try
+            if (glossaryResolved && glossaryCache.TryGetValue(langPairKey, out var cachedId))
             {
-                glossaryHttpResponse.EnsureSuccessStatusCode();
-
-                var glossaryJsonString = await glossaryHttpResponse.Content.ReadAsStringAsync(ct);
-                var glossaryJsonResponse = JsonSerializer.Deserialize<GlossariesDto>(glossaryJsonString)!;
-
-                foreach (var glossary in glossaryJsonResponse.Glossaries)
-                {
-                    if (options.GlossaryByName.Equals(glossary.Name, StringComparison.Ordinal))
-                    {
-                        if (glossary.Ready)
-                        {
-                            glossaryId = glossary.GlossaryId;
-                            resolvedGlossaryId = glossaryId;
-                        }
-                        else
-                        {
-                            glossaryResolved = false;
-                        }
-
-                        break;
-                    }
-                }
+                glossaryId = cachedId;
             }
-            catch (Exception ex)
+
+            if (!string.IsNullOrWhiteSpace(options.GlossaryByName) && string.IsNullOrWhiteSpace(glossaryId) && !glossaryResolved)
             {
-                glossaryResolved = false;
-                AddError(TranslationResult.Failed(ex));
+                glossaryResolved = true;
+
+                var glossaryUrl = url.Replace("/translate", "/glossaries");
+                using var glossaryHttpRequest = new HttpRequestMessage(HttpMethod.Get, glossaryUrl);
+                using var glossaryHttpResponse = await httpClient.SendAsync(glossaryHttpRequest, ct);
+
+                try
+                {
+                    glossaryHttpResponse.EnsureSuccessStatusCode();
+
+                    var glossaryJsonString = await glossaryHttpResponse.Content.ReadAsStringAsync(ct);
+                    var glossaryJsonResponse = JsonSerializer.Deserialize<GlossariesDto>(glossaryJsonString)!;
+
+                    foreach (var glossary in glossaryJsonResponse.Glossaries)
+                    {
+                        if (options.GlossaryByName.Equals(glossary.Name, StringComparison.Ordinal) && glossary.Ready)
+                        {
+                            var key = $"{GetLanguageCode(glossary.SourceLang)}_{GetLanguageCode(glossary.TargetLang)}";
+                            glossaryCache[key] = glossary.GlossaryId;
+                        }
+                    }
+
+                    glossaryCache.TryGetValue(langPairKey, out glossaryId);
+                }
+                catch (Exception ex)
+                {
+                    glossaryResolved = false;
+                    AddError(TranslationResult.Failed(ex));
+                }
             }
         }
 
@@ -237,10 +239,19 @@ public sealed class DeepLTranslationService(IHttpClientFactory httpClientFactory
 
     private void InvalidateGlossaryCacheIfResolved(string? glossaryId)
     {
-        if (!string.IsNullOrWhiteSpace(glossaryId) && glossaryId == resolvedGlossaryId)
+        if (string.IsNullOrWhiteSpace(glossaryId))
         {
-            resolvedGlossaryId = null;
-            glossaryResolved = false;
+            return;
+        }
+
+        foreach (var kvp in glossaryCache)
+        {
+            if (kvp.Value == glossaryId)
+            {
+                glossaryCache.TryRemove(kvp.Key, out _);
+                glossaryResolved = false;
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
DeepL: Added support for the parameters tag_handling and glossary_id via application.config:

    "translations.deepl.tagHandling": "html" // Enables translation of HTML content, e.g. from rich text editors.
    "translations.deepl.glossaryById": "{client-glossary-id}" // Uses a specific DeepL glossary ID for translations.
    "translations.deepl.glossaryByName": "{client-glossary-name}" // Resolves the glossary ID by glossary name before translation.

DeepL glossary handling:
When a glossary is replaced or recreated, its glossary ID may change. To keep glossary functionality stable in such cases, keep the glossary name unchanged and configure glossaryByName instead of glossaryById.

If a glossary name is configured, the glossary lookup is performed using the glossary name together with the source and target language pair.

The resolved glossary ID is cached in memory. If the glossary becomes invalid (for example because it was deleted or recreated), the cache is invalidated when a translation request fails and the glossary ID is resolved again on the next request.

Note: DeepL requires source_lang to be specified explicitly when a glossary is used for translation.
