### PR TITLE
ImageResize: fix missing pad color for resize operations

### DIFF
--- a/assets/Squidex.Assets.ImageSharp/ImageSharpThumbnailGenerator.cs
+++ b/assets/Squidex.Assets.ImageSharp/ImageSharpThumbnailGenerator.cs
@@ -77,7 +77,8 @@ public sealed class ImageSharpThumbnailGenerator(IHttpClientFactory httpClientFa
                 if (w > 0 || h > 0)
                 {
                     var resizeMode = GetResizeMode(options, w, h, image);
-                    var resizeOptions = new ImageSharpOptions { Size = new Size(w, h), Mode = resizeMode, PremultiplyAlpha = true };
+                    var backgroundColor = options.Background != null && Color.TryParse(options.Background, out var color) ? color : Color.Transparent;
+                    var resizeOptions = new ImageSharpOptions { Size = new Size(w, h), Mode = resizeMode, PremultiplyAlpha = true, PadColor = backgroundColor };
 
                     if (options.FocusX.HasValue && options.FocusY.HasValue)
                     {
@@ -89,14 +90,7 @@ public sealed class ImageSharpThumbnailGenerator(IHttpClientFactory httpClientFa
 
                     operation.Resize(resizeOptions);
 
-                    if (options.Background != null && Color.TryParse(options.Background, out var color))
-                    {
-                        operation.BackgroundColor(color);
-                    }
-                    else
-                    {
-                        operation.BackgroundColor(Color.Transparent);
-                    }
+                    operation.BackgroundColor(backgroundColor);
                 }
 
                 if (watermark != null)


### PR DESCRIPTION
Using same background color for operation as PadColor for resizing/upscales